### PR TITLE
[codex] tighten NixOS option placement and descriptions

### DIFF
--- a/modules/nixos/roles/desktop/default.nix
+++ b/modules/nixos/roles/desktop/default.nix
@@ -14,6 +14,8 @@ in
     ./explorer.nix
   ];
 
+  options.hostConfig.roles.desktop = lib.mkEnableOption "Enable desktop features.";
+
   config = lib.mkIf cfg {
     services.gnome.gnome-keyring.enable = true;
 

--- a/modules/nixos/roles/desktop/explorer.nix
+++ b/modules/nixos/roles/desktop/explorer.nix
@@ -8,8 +8,6 @@ let
   cfg = config.hostConfig.roles.desktop;
 in
 {
-  options.hostConfig.roles.desktop = lib.mkEnableOption "Enable hyprland and desktop features.";
-
   config = lib.mkIf cfg {
     programs = {
       thunar = {

--- a/modules/nixos/services/bluetooth.nix
+++ b/modules/nixos/services/bluetooth.nix
@@ -7,7 +7,7 @@ let
   cfg = config.hostConfig.services.bluetooth;
 in
 {
-  options.hostConfig.services.bluetooth = lib.mkEnableOption "Enable bluetooth features.";
+  options.hostConfig.services.bluetooth = lib.mkEnableOption "Enable Bluetooth support.";
 
   config = lib.mkIf cfg {
     hardware.bluetooth.enable = true;

--- a/modules/nixos/services/opengl.nix
+++ b/modules/nixos/services/opengl.nix
@@ -8,7 +8,7 @@ let
   cfg = config.hostConfig.services.opengl;
 in
 {
-  options.hostConfig.services.opengl = lib.mkEnableOption "Enable opengl features.";
+  options.hostConfig.services.opengl = lib.mkEnableOption "Enable OpenGL support.";
 
   config = lib.mkIf cfg {
     hardware = {

--- a/modules/nixos/services/podman.nix
+++ b/modules/nixos/services/podman.nix
@@ -7,7 +7,7 @@ let
   cfg = config.hostConfig.services.podman;
 in
 {
-  options.hostConfig.services.podman = lib.mkEnableOption "Enable podman containerization engine:";
+  options.hostConfig.services.podman = lib.mkEnableOption "Enable Podman containerization.";
 
   config = lib.mkIf cfg {
     virtualisation.containers.enable = true;

--- a/modules/nixos/services/printer.nix
+++ b/modules/nixos/services/printer.nix
@@ -7,7 +7,7 @@ let
   cfg = config.hostConfig.services.printing;
 in
 {
-  options.hostConfig.services.printing = lib.mkEnableOption "Enable printing service.";
+  options.hostConfig.services.printing = lib.mkEnableOption "Enable printing support.";
 
   config = lib.mkIf cfg {
     services = {

--- a/modules/nixos/services/sound.nix
+++ b/modules/nixos/services/sound.nix
@@ -7,7 +7,7 @@ let
   cfg = config.hostConfig.services.sound;
 in
 {
-  options.hostConfig.services.sound = lib.mkEnableOption "Enable sound.";
+  options.hostConfig.services.sound = lib.mkEnableOption "Enable sound support.";
 
   config = lib.mkIf cfg {
     services = {

--- a/modules/nixos/services/tailscale.nix
+++ b/modules/nixos/services/tailscale.nix
@@ -7,7 +7,7 @@ let
   cfg = config.hostConfig.services.tailscale;
 in
 {
-  options.hostConfig.services.tailscale = lib.mkEnableOption "Enable tailscaled.";
+  options.hostConfig.services.tailscale = lib.mkEnableOption "Enable Tailscale.";
 
   config = lib.mkIf cfg {
     services.tailscale.enable = true;

--- a/modules/nixos/system/boot.nix
+++ b/modules/nixos/system/boot.nix
@@ -8,11 +8,12 @@ let
 in
 {
   options.hostConfig.boot = {
-    enable = lib.mkEnableOption "Enable install / config of bootloader";
-    armSupport = lib.mkEnableOption "Enable arm cross-compiler support";
+    enable = lib.mkEnableOption "Enable bootloader configuration.";
+    armSupport = lib.mkEnableOption "Enable ARM cross-compilation support.";
     supportedFilesystems = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
+      description = "Additional filesystem types to support at boot.";
     };
   };
 

--- a/modules/nixos/system/user.nix
+++ b/modules/nixos/system/user.nix
@@ -10,10 +10,10 @@ let
 in
 {
   options.hostConfig.user = {
-    name = mylib.mkOpt lib.types.str "Name of user.";
-    initialHashedPassword = mylib.mkOpt lib.types.str "Password of user.";
-    extraGroups = mylib.mkOpt' (lib.types.listOf lib.types.str) [ ] "Additional groups for the user.";
-    extraOptions = mylib.mkOpt lib.types.attrs "Additional options for the user.";
+    name = mylib.mkOpt lib.types.str "Username for the account.";
+    initialHashedPassword = mylib.mkOpt lib.types.str "Initial hashed password for the account.";
+    extraGroups = mylib.mkOpt' (lib.types.listOf lib.types.str) [ ] "Additional supplemental groups.";
+    extraOptions = mylib.mkOpt lib.types.attrs "Extra user account options.";
   };
 
   config = {


### PR DESCRIPTION
Tighten the NixOS module option structure and wording.

- move the desktop role enable option to the desktop role entrypoint
- keep submodules focused on config instead of option declaration
- normalize several option descriptions so they read consistently across the tree

Validation:
- `nix eval .#nixosConfigurations.zion.config.system.build.toplevel.drvPath`
- `nix eval .#homeConfigurations."rap@zion".activationPackage.drvPath`